### PR TITLE
Speed up kWayStratifiedY

### DIFF
--- a/R/outOfSample.R
+++ b/R/outOfSample.R
@@ -211,16 +211,20 @@ kWayStratifiedY <- function(nRows,nSplits,dframe,y) {
   # order by y
   d <- d[order(d$y),]
   # mix within order segments
-  for(si in seq_len(ceiling(nRows/nSplits))) {
+  rows_per_split <- ceiling(nRows/nSplits)
+  mix_idx <- vector("list", rows_per_split)
+  for(si in seq_len(rows_per_split)) {
     leftI <- si*nSplits - (nSplits-1)
     rightI <- min(si*nSplits,nRows)
     widthI <- 1+rightI-leftI
     if(widthI>1) {
       oldIndices <- leftI:rightI
-      newIndices <- oldIndices[sample.int(widthI,widthI,replace=FALSE)]
-      d[newIndices,] <- d[oldIndices,]
+      mix_idx[[si]] <- oldIndices[sample.int(widthI,widthI,replace=FALSE)]
+    } else {
+      mix_idx[[si]] <- leftI:rightI
     }
   }
+  d[unlist(mix_idx),] <- d
   d$group <- (fullSeq %% nSplits) + 1
   carveUp <-  split(d$index,d$group)
   evalSets <- lapply(carveUp,


### PR DESCRIPTION
I was trying `designTreatmentsN` with my data and saw that it was taking unexpectedly long time for what it was supposed to do. Profiling indicated that there were hundreds of thousands of data.frame copies and many garbage collections happening [during the subset rows assignment in kWayStratifiedY](https://github.com/WinVector/vtreat/blob/dac8a6efebf371b62eeed123ff714cb45c454a84/R/outOfSample.R#L221). A simple modification in this PR produces equivalent results but faster.

E.g., the following example was taking about 4.5 minutes before the fix and it was just under 10 seconds after the fix:
```R
library(nycflights13)
t <- proc.time()
trt <- designTreatmentsN(flights[!is.na(flights$air_time)],
                         c('air_time', 'carrier', 'origin', 'dest'), 'air_time',
                         codeRestriction = 'catN', rareCount = 100)
proc.time() - t
```
And here's another example showing ~40x speedup for 100K cases and the equivalency of the results:
```R
# Load vtreat before this PR, and edit kWayStratifiedY_fixed to be the same as in this PR
kWayStratifiedY_fixed <- kWayStratifiedY
fix(kWayStratifiedY_fixed)

library(microbenchmark)
N <- 100000
microbenchmark(
  {set.seed(1); kWayStratifiedY(N, 3, NULL, rexp(N, 1))},
  {set.seed(1); kWayStratifiedY_fixed(N, 3, NULL, rexp(N, 1))},
  times = 5,
  check = function(v) all(sapply(v[-1], function(x) identical(v[[1]], x)))
  )
# Unit: milliseconds
#                                                                   expr        min         lq       mean     median         uq        max neval cld
#        {     set.seed(1)     kWayStratifiedY(N, 3, NULL, rexp(N, 1)) } 11467.5619 11572.2486 11590.5646 11598.3650 11641.8635 11672.7841     5   b
#  {     set.seed(1)     kWayStratifiedY_fixed(N, 3, NULL, rexp(N, 1)) }   281.9261   288.7616   293.1131   289.2523   292.5306   313.0947     5  a
```


