### PR TITLE
Refactor center_scale

### DIFF
--- a/R/center_scale.R
+++ b/R/center_scale.R
@@ -26,11 +26,11 @@
 center_scale <- function(d, 
                          center,
                          scale) {
-  for(ni in names(center)) {
+  for(ni in intersect(names(center), names(d))) {
     d[[ni]] <- d[[ni]] - center[[ni]]
   }
     
-  for(ni in names(scale)) {
+  for(ni in intersect(names(scale), names(d))) {
     si <- scale[[ni]]
     if(all(is.finite(si), si!=0.0)) {
       d[[ni]] <- d[[ni]] / scale[[ni]]

--- a/R/center_scale.R
+++ b/R/center_scale.R
@@ -29,10 +29,11 @@ center_scale <- function(d,
   for(ni in names(center)) {
     d[[ni]] <- d[[ni]] - center[[ni]]
   }
+    
   for(ni in names(scale)) {
     si <- scale[[ni]]
-    if((length(si)==1) && (!is.na(si)) && (!is.infinite(si)) && (si!=0.0)) {
-      d[[ni]] <- d[[ni]]/scale[[ni]]
+    if(all(is.finite(si), si!=0.0)) {
+      d[[ni]] <- d[[ni]] / scale[[ni]]
     }
   }
   d


### PR DESCRIPTION
This lets scaling be vectorized just like centering.

While in here, also fixed issue when `d` lacks columns that `center`/`scale` do have.

As a (contrived) example, 

    center_scale(mtcars[,c("mpg", "hp", "wt")], c(), lapply(mtcars, ave, mtcars$am)) 

now will scale `mpg`,`hp`,`wt` by group mean. 